### PR TITLE
Comment out the mentioned test cases for today to check if they are causing all items to be hidden in the Test Automation order guide. 

### DIFF
--- a/regression1.xml
+++ b/regression1.xml
@@ -26,10 +26,10 @@
             <class name="com.cutanddry.qa.tests.OrderGuide.VerifyHidingAnItemFromOrderGuideTest" />
             <class name="com.cutanddry.qa.tests.OrderGuide.VerifyUnhideItemsFromOrderGuideTest" />
             <class name="com.cutanddry.qa.tests.OrderGuide.VerifyTheSearchFeatureTest" />
-            <class name="com.cutanddry.qa.tests.OrderGuide.VerifyCreatingOrdersWithUploadingExcelFileTest" />
+<!--            <class name="com.cutanddry.qa.tests.OrderGuide.VerifyCreatingOrdersWithUploadingExcelFileTest" />-->
             <class name="com.cutanddry.qa.tests.OrderGuide.VerifyEditingOrderGuideWithCatalogItemsTest" />
-            <class name="com.cutanddry.qa.tests.OrderGuide.VerifyEditingOrdersImportingOrderGuideTest" />
-            <class name="com.cutanddry.qa.tests.OrderGuide.VerifyEditingOrdersWithUploadingExcelFileTest" />
+<!--            <class name="com.cutanddry.qa.tests.OrderGuide.VerifyEditingOrdersImportingOrderGuideTest" />-->
+<!--            <class name="com.cutanddry.qa.tests.OrderGuide.VerifyEditingOrdersWithUploadingExcelFileTest" />-->
             <class name="com.cutanddry.qa.tests.OrderGuide.VerifyTheSortOptionsTest" />
             <class name="com.cutanddry.qa.tests.OrderGuide.VerifyTheCutOffTimeForPickup" />
             <class name="com.cutanddry.qa.tests.OrderGuide.VerifyThePickUpDisplayTerm" />


### PR DESCRIPTION
- VerifyEditingOrdersWithUploadingExcelFileTest - VerifyCreatingOrdersWithUploadingExcelFileTest - VerifyEditingOrdersImportingOrderGuideTest