### PR TITLE
add VerifyGenericAccountHoldMessageIsDisplayedOnOrderSubmissionTest

### DIFF
--- a/regression9.xml
+++ b/regression9.xml
@@ -31,7 +31,7 @@
             <class name="com.cutanddry.qa.tests.DP_Specific_Suppliers.ValidateSupplierSelectionModalCloseBehaviourTest"/>
             <class name="com.cutanddry.qa.tests.DP_Specific_Suppliers.VerifyLastOrderedPricesAreNotShowingInOrderGuidesTest"/>
             <class name="com.cutanddry.qa.tests.DP_Specific_Suppliers.VerifyCustomAccountHoldMessageIsDisplayedForCarmelaOnOrderSubmissionTest"/>
-
+            <class name="com.cutanddry.qa.tests.DP_Specific_Suppliers.VerifyGenericAccountHoldMessageIsDisplayedOnOrderSubmissionTest"/>
         </classes>
     </test>
 </suite>

--- a/src/main/java/com/cutanddry/qa/pages/CustomersPage.java
+++ b/src/main/java/com/cutanddry/qa/pages/CustomersPage.java
@@ -172,7 +172,7 @@ By lbl_itemPriceFirstRow = By.xpath("((//td//span//div[@data-tip='View Product D
     String SelectCustomerByCode = "//td[contains(text(),'CODE')]";
     String txt_customerProfile = "//div[contains(@class, 'd-flex') and contains(text(), 'BUSINESSNAME')]";
     By tb_orders = By.xpath("//a[text()='Orders' and @role='tab']");
-    String specificOrderRecord = "//tr/td[text()='ORDER_ID']";
+    String specificOrderRecord = "//tr//*[text()='ORDER_ID']";
     String orderTitle = "//h2[contains(text(),'Order #ORDER_ID')]";
     By btn_addToCartPDP = By.xpath("(//button[contains(text(), 'Add to Cart')])[1]");
     By lbl_pickUp = By.xpath("//span[text()='Pickup/Will Call']");

--- a/src/test/java/com/cutanddry/qa/tests/DP_Specific_Suppliers/VerifyGenericAccountHoldMessageIsDisplayedOnOrderSubmissionTest.java
+++ b/src/test/java/com/cutanddry/qa/tests/DP_Specific_Suppliers/VerifyGenericAccountHoldMessageIsDisplayedOnOrderSubmissionTest.java
@@ -1,0 +1,80 @@
+package com.cutanddry.qa.tests.DP_Specific_Suppliers;
+
+import com.cutanddry.qa.base.TestBase;
+import com.cutanddry.qa.data.models.User;
+import com.cutanddry.qa.functions.Customer;
+import com.cutanddry.qa.functions.Dashboard;
+import com.cutanddry.qa.functions.Login;
+import com.cutanddry.qa.utils.JsonUtil;
+import org.testng.Assert;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
+
+public class VerifyGenericAccountHoldMessageIsDisplayedOnOrderSubmissionTest extends TestBase {
+    static User user;
+    static String Dp_Name = "47837013 - Brandon IFC Cut+Dry Agent - Independent Foods Co";
+    static String customerId = "30275";
+    static String OperatorName = "372460856";
+    static String holdMessage = "Your account is on hold by your supplier. Your order could not be submitted, but has been saved as a Draft. Please contact your supplier about your account status and resubmit your order.";
+    String itemName,searchItemCode;
+    static double itemPrice;
+
+
+
+    @BeforeMethod
+    public void setUp(){
+        initialization();
+        user = JsonUtil.readUserLogin();
+    }
+
+    @Test(groups = "DOT-TC-533")
+    public void VerifyGenericAccountHoldMessageIsDisplayedOnOrderSubmission() throws InterruptedException {
+        SoftAssert softAssert = new SoftAssert();
+        Login.loginAsRestaurant(user.getEmailOrMobile(), user.getPassword());
+        Dashboard.isUserNavigatedToDashboard();
+
+        Login.navigateToLoginAs();
+        Login.goToDistributor(Dp_Name);
+        Dashboard.isUserNavigatedToDistributorDashboard();
+        Assert.assertTrue(Dashboard.isUserNavigatedToDistributorDashboard(),"login error");
+
+        Dashboard.navigateToCustomers();
+        Customer.searchCustomerByCode(customerId);
+        softAssert.assertTrue(Customer.isCustomerSearchResultByCodeDisplayed(customerId),"search error");
+        Customer.clickOnCustomerCode(customerId);
+        Customer.clickOnEditAccHolds();
+        Customer.clickOnAccDropdown();
+        Customer.clickOnHardHold();
+        Customer.clickOnSaveDP();
+        softAssert.assertTrue(Customer.isHardHoldSelected(),"acc select error");
+
+        Login.closePreviousTab();
+
+        Login.navigateToLoginAs();
+        Login.logInToOperatorAsWhiteLabel(OperatorName);
+        Dashboard.navigateToOrder();
+        Assert.assertTrue(Dashboard.isUserNavigatedToOrderGuide(),"navigation error");
+
+        itemName = Customer.getItemNameFirstRow();
+        searchItemCode = Customer.getItemCodeFirstRow();
+        itemPrice = Customer.getActiveItemPriceFirstRow();
+        Customer.increaseFirstRowQtySpecificCustomer(15);
+        Customer.checkoutItems();
+        softAssert.assertTrue(Customer.isReviewOrderTextDisplayed(), "The user is unable to land on the Review Order page.");
+        Customer.submitOrder();
+        softAssert.assertTrue(Customer.isAccountHoldPopUpDisplay(),"account not hold");
+        softAssert.assertTrue(Customer.isAccountHoldMessageDisplay(holdMessage),"account hold message not display");
+        softAssert.assertAll();
+
+    }
+
+    @AfterMethod
+    public void tearDown(ITestResult result) {
+        takeScreenshotOnFailure(result);
+        closeAllBrowsers();
+    }
+
+}


### PR DESCRIPTION
This pull request automates the following test cases

1. VerifyGenericAccountHoldMessageIsDisplayedOnOrderSubmissionTest - DOT-TC-533

- fixed automation failure

<img width="1792" alt="Screenshot 2025-05-07 at 08 47 58" src="https://github.com/user-attachments/assets/600cb01e-c8b6-4492-accc-32d93ed33863" />
